### PR TITLE
Fix to mounted filmbox

### DIFF
--- a/frontend/src/pages/game/Game.jsx
+++ b/frontend/src/pages/game/Game.jsx
@@ -6,6 +6,8 @@ import { getInitialMovie } from "../../services/movies";
 
 // components to import
 import FilmBox from "../../components/FilmBox";
+import Header from "../../components/header";
+import Footer from "../../components/Footer";
 
 const GamePage = () => {
   let [gameState, setGameState] = useState("idle");
@@ -45,6 +47,7 @@ const GamePage = () => {
 
   return (
     <div>
+      <Header />
       <h1>Enter your guess here</h1>
       <form>
         <input
@@ -56,6 +59,7 @@ const GamePage = () => {
           <FilmBox movie={targetMovie} />
         </div>
       </form>
+      <Footer />
     </div>
   );
 };

--- a/frontend/src/pages/game/Game.jsx
+++ b/frontend/src/pages/game/Game.jsx
@@ -17,25 +17,30 @@ const GamePage = () => {
   let [input, setInput] = useState("");
 
   useEffect(() => {
+    let isMounted = true; // Flag to track if the component is mounted
+
     const fetchInitialMovie = async () => {
       try {
-        const data = await getInitialMovie(); // Wait for the movie data
-        console.log("Data received from getInitialMovie:", data); // Debugging log
-        if (data && data.id) {
-          setTargetMovie(data); // Set the target movie
-          appendToMoviesPlayed((prev) => [...prev, data.id]);
-          // Append the movie ID to the played list
-        } else {
-          console.error("Invalid movie data:", data);
+        const data = await getInitialMovie();
+        if (isMounted) {
+          console.log("Data received from getInitialMovie:", data);
+          if (data && data.id) {
+            setTargetMovie(data);
+            appendToMoviesPlayed((prev) => [...prev, data.id]);
+          } else {
+            console.error("Invalid movie data:", data);
+          }
         }
       } catch (error) {
         console.error("Error setting target movie:", error);
       }
     };
 
-    fetchInitialMovie(); // Call the async function
+    fetchInitialMovie();
 
-    setGameState("active"); // Set the game state to active
+    return () => {
+      isMounted = false; // Cleanup to prevent setting state on unmounted component
+    };
   }, []);
 
   return (


### PR DESCRIPTION
If useEffect is triggered twice, it will only show the Mounted movie to cleanup setting state and make sure that a movie isn't briefly shown before switching to another movie.